### PR TITLE
Fix crash when user not implemented minimumDate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.9.2](https://github.com/Husseinhj/FSCalendar/releases/tag/2.9.2)
+### Changes :
+- Fix bug crash library in Persian locale if `minimumDate` method wasn't implemented by developer. now implementing the `minimumDate()` not force anymore.
+
 ## [2.9.1](https://github.com/Husseinhj/FSCalendar/releases/tag/2.9.1)
 ### Changes :
 - Fix bug for supporting iOS 7.0

--- a/FSCalendar+Persian.podspec
+++ b/FSCalendar+Persian.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
 
   s.name             = "FSCalendar+Persian"
-  s.version          = "2.9.1"
+  s.version          = "2.9.2"
   s.summary          = "RTL (Persian and Arabic) version of FSCalendar. A superiorly awesome iOS7+ calendar control, compatible with Objective-C and Swift."
   
   s.homepage         = "https://github.com/Husseinhj/FSCalendar"
-  s.screenshots      = "https://raw.githubusercontent.com/Husseinhj/FSCalendar/master/ScreenShots/Simulator%20Screen%20Shot%20-%20iPhone%208%20Plus%20-%202018-03-01%20at%2016.46.44.png","https://github.com/Husseinhj/FSCalendar/raw/master/ScreenShots/Simulator%20Screen%20Shot%20-%20iPhone%208%20Plus%20-%202018-03-01%20at%2015.26.50.png"
+  s.screenshots      = "https://github.com/Husseinhj/FSCalendar/raw/master/docs/Screenshots/English/DIY-Example-en.png", "https://raw.githubusercontent.com/Husseinhj/FSCalendar/master/docs/Screenshots/Persian/DIY-Example-fa.png", "https://github.com/Husseinhj/FSCalendar/raw/master/docs/Screenshots/Arabic/DIY-Example-ar.png"
   s.license          = 'MIT'
   s.author           = { "Hussein Habibi Juybari" => "hussein.juybari@gmail.com" }
   s.source           = { :git => "https://github.com/Husseinhj/FSCalendar.git", :tag => s.version.to_s }

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -1714,10 +1714,14 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 {
     if (_needsRequestingBoundingDates) {
         _needsRequestingBoundingDates = NO;
+        
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.dateFormat = @"yyyy-MM-dd";
+        
         self.formatter.dateFormat = @"yyyy-MM-dd";
-        NSDate *newMin = [self.dataSourceProxy minimumDateForCalendar:self]?:[self.formatter dateFromString:@"1970-01-01"];
+        NSDate *newMin = [self.dataSourceProxy minimumDateForCalendar:self]?:[dateFormatter dateFromString:@"1970-01-01"];
         newMin = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:newMin options:0];
-        NSDate *newMax = [self.dataSourceProxy maximumDateForCalendar:self]?:[self.formatter dateFromString:@"2099-12-31"];
+        NSDate *newMax = [self.dataSourceProxy maximumDateForCalendar:self]?:[dateFormatter dateFromString:@"2099-12-31"];
         newMax = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:newMax options:0];
         
         NSAssert([self.gregorian compareDate:newMin toDate:newMax toUnitGranularity:NSCalendarUnitDay] != NSOrderedDescending, @"The minimum date of calendar should be earlier than the maximum.");


### PR DESCRIPTION
### Changes :
- Fix bug crash library in Persian locale if `minimumDate` method wasn't implemented by developer. now implementing the `minimumDate()` not force anymore.